### PR TITLE
인증 방식 및 통신 넣어야 할 부분

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-03-07T06:13:08.685771700Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-03-12T00:58:56.656247500Z" />
   </component>
 </project>

--- a/app/src/main/java/com/example/sofront/AuthBottomSheet.kt
+++ b/app/src/main/java/com/example/sofront/AuthBottomSheet.kt
@@ -15,6 +15,8 @@ import com.example.sofront.databinding.FragmentAuthBottomSheetBinding
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
 
 class AuthBottomSheet : BottomSheetDialogFragment() {
 
@@ -29,15 +31,26 @@ class AuthBottomSheet : BottomSheetDialogFragment() {
         savedInstanceState: Bundle?
     ): View? {
         val binding = FragmentAuthBottomSheetBinding.inflate(layoutInflater)
-        val ID = arguments?.getString("ID")
+        val UID = arguments?.getString("UID")
         val PWD = arguments?.getString("PWD")
         val Email = arguments?.getString("Email")
         binding.numAuth.setOnClickListener{
             val intent = Intent(signUpAuth, NumAuth::class.java)
-            intent.putExtra("ID", ID)
-            intent.putExtra("PWD", PWD)
-            intent.putExtra("Email", Email)
+            intent.putExtra("UID", UID.toString())
+            intent.putExtra("PWD", PWD.toString())
+            intent.putExtra("Email", Email.toString())
             startActivity(intent)
+        }
+
+        binding.emailAuth.setOnClickListener{
+            val user = Firebase.auth.currentUser
+
+            user!!.sendEmailVerification()
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        Log.d(TAG, "Email sent.")
+                    }
+                }
         }
         return binding.root
     }
@@ -66,7 +79,7 @@ class AuthBottomSheet : BottomSheetDialogFragment() {
     }
 
     private fun getBottomSheetDialogDefaultHeight(): Int {
-        return getWindowHeight() * 50 / 100
+        return getWindowHeight() * 40 / 100
     }
 
     private fun getWindowHeight(): Int {

--- a/app/src/main/java/com/example/sofront/DetailInfoActivity.kt
+++ b/app/src/main/java/com/example/sofront/DetailInfoActivity.kt
@@ -4,8 +4,10 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.widget.Toast
 import android.widget.ToggleButton
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.app.ActivityCompat
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 
@@ -22,11 +24,10 @@ class DetailInfoActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityDetailInfoBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
         val UID = intent.getStringExtra("UID")
-        val UName = intent.getStringExtra("UName")
 
         Log.d("UID : ", UID.toString())
-        Log.d("UID : ", UName.toString())
 
         setList()
         adapter.toggleList = toggleList
@@ -123,5 +124,19 @@ class DetailInfoActivity : AppCompatActivity() {
             userInfo.user_number=="" -> false
             else -> true
         }
+    }
+
+    private var backPressedTime : Long = 0
+    override fun onBackPressed() {
+        // 2초내 다시 클릭하면 앱 종료
+        if (System.currentTimeMillis() - backPressedTime < 1500) {
+            ActivityCompat.finishAffinity(this); // 액티비티를 종료하고
+            System.exit(0); // 프로세스를 종료
+            return
+        }
+
+        // 처음 클릭 메시지
+        Toast.makeText(this, "'뒤로' 버튼을 한번 더 누르시면 앱이 종료됩니다.", Toast.LENGTH_SHORT).show()
+        backPressedTime = System.currentTimeMillis()
     }
 }

--- a/app/src/main/java/com/example/sofront/MainActivity.kt
+++ b/app/src/main/java/com/example/sofront/MainActivity.kt
@@ -1,12 +1,16 @@
 package com.example.sofront
 
+import android.content.ContentValues.TAG
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager2.widget.ViewPager2
 import com.example.sofront.databinding.ActivityMainBinding
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
 
 
 class MainActivity : AppCompatActivity() {
@@ -25,6 +29,18 @@ class MainActivity : AppCompatActivity() {
         adapter.fragments = fragmentList
         binding.intro.adapter = adapter
         binding.wormDotsIndicator.setViewPager2(binding.intro)
+
+        val user = Firebase.auth.currentUser
+        if(user != null){
+            Toast.makeText(this, "인증된 사용자입니다.", Toast.LENGTH_SHORT).show()
+            Log.d("user : ", user.toString())
+            val uid = user.uid
+//            Firebase.auth.signOut()
+            // <통신> 여기서 우리 서버에 해당 uid를 가진 db가 있는지 확인. 있으면 바로 메인화면으로 넘어가고, 없으면 인증페이지(NumAuth)로 넘어감
+
+        }else{
+            Toast.makeText(this, "로그인 및 회원가입을 진행해주세요.", Toast.LENGTH_SHORT).show()
+        }
 
         binding.intro.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback(){
             override fun onPageSelected(position: Int) {

--- a/app/src/main/java/com/example/sofront/NumAuth.kt
+++ b/app/src/main/java/com/example/sofront/NumAuth.kt
@@ -1,5 +1,6 @@
 package com.example.sofront
 
+import android.content.ContentValues.TAG
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
@@ -18,7 +19,7 @@ class NumAuth : AppCompatActivity() {
     val auth = Firebase.auth
     var verificationId = ""
 
-    var ID:String = ""
+    var UID:String = ""
     var PWD:String = ""
     var Email:String = ""
 
@@ -27,11 +28,22 @@ class NumAuth : AppCompatActivity() {
             if(task.isSuccessful){
                 Toast.makeText(this, "인증에 성공하였습니다.", Toast.LENGTH_SHORT).show()
                 val intent = Intent(this, DetailInfoActivity::class.java)
-                intent.putExtra("ID", ID)
+                intent.putExtra("UID", UID)
                 intent.putExtra("PWD", PWD)
                 intent.putExtra("Email", Email)
-                startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP))
-                this.finish()
+
+                //<통신> 해당 uid를 기본 키로 갖는 문서를 생성해줌
+
+                //전화번호 인증 삭제
+                val user = Firebase.auth.currentUser!!
+                user.delete()
+                    .addOnCompleteListener { task ->
+                        if (task.isSuccessful) {
+                            Log.d(TAG, "User account deleted.")
+                            startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP))
+                            this.finish()
+                        }
+                    }
             }else {
                 Toast.makeText(this, "인증에 실패하였습니다.", Toast.LENGTH_SHORT).show()
             }
@@ -43,16 +55,14 @@ class NumAuth : AppCompatActivity() {
         val binding = ActivityNumAuthBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        ID = intent.getStringExtra("ID").toString()
-        PWD = intent.getStringExtra("PWD").toString()
-        Email = intent.getStringExtra("Email").toString()
-        Log.d("해위", ID+PWD+Email)
+        UID = intent.getStringExtra("UID").toString()
 
         var authCompleted:Boolean = false
 
         binding.geAuth.setOnClickListener{
             if(binding.numSecondEt.text.toString() != "" && binding.numThirdEt.text.toString() != ""){
                 val phoneNum:String = "+8210"+ binding.numSecondEt.text.toString() + binding.numThirdEt.text.toString()
+                Toast.makeText(this, "인증번호가 전송되었습니다.\n잠시만 기다려주세요!", Toast.LENGTH_SHORT).show()
                 authCompleted = true
 
                 val callbacks = object : PhoneAuthProvider.OnVerificationStateChangedCallbacks() {

--- a/app/src/main/res/layout/activity_num_auth.xml
+++ b/app/src/main/res/layout/activity_num_auth.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".NumAuth"
-    android:padding="25dp">
+    android:padding="15dp">
 
     <TextView
         android:id="@+id/title"
@@ -18,7 +18,8 @@
         android:textColor="@color/black"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
-        android:paddingTop="40dp"/>
+        android:paddingTop="40dp"
+        android:paddingLeft="10dp"/>
 
     <TextView
         android:id="@+id/sub"
@@ -28,7 +29,8 @@
         android:fontFamily="@font/nixgonm"
         app:layout_constraintTop_toBottomOf="@id/title"
         android:textSize="20sp"
-        app:layout_constraintLeft_toLeftOf="parent"/>
+        app:layout_constraintLeft_toLeftOf="parent"
+        android:paddingLeft="10dp"/>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/lay"

--- a/app/src/main/res/layout/activity_sign_up_auth.xml
+++ b/app/src/main/res/layout/activity_sign_up_auth.xml
@@ -72,65 +72,65 @@
                         android:paddingBottom="30dp">
 
                         <TextView
-                            android:id="@+id/id_tv"
+                            android:id="@+id/email_tv"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="아이디*"
+                            android:text="이메일"
                             android:textColor="@color/black"
                             android:fontFamily="@font/nixgonm"
-                            android:textSize="20sp"
+                            android:textSize="18sp"
                             app:layout_constraintLeft_toLeftOf="parent"
-                            app:layout_constraintTop_toTopOf="@id/id_et"
+                            app:layout_constraintTop_toTopOf="@id/email_id_et"
                             android:paddingTop="10dp"/>
 
                         <EditText
-                            android:id="@+id/id_et"
+                            android:id="@+id/email_id_et"
                             android:layout_width="wrap_content"
                             android:layout_height="40dp"
-                            android:ems="10"
+                            android:ems="7"
+                            android:hint="abc1234"
                             android:background="@drawable/signup_eidt"
-                            android:hint="아이디 입력"
                             android:letterSpacing="-0.05"
                             android:fontFamily="@font/nixgonm"
-                            android:gravity="center"
-                            app:layout_constraintStart_toStartOf="@id/pwd_et"
-                            app:layout_constraintTop_toTopOf="parent"
-                            android:maxLength="15"
                             android:maxLines="1"
+                            android:gravity="center"
+                            app:layout_constraintStart_toStartOf="@id/pwd_ck_et"
+                            app:layout_constraintTop_toTopOf="parent"
                             android:singleLine="true"
                             android:imeOptions="actionDone"/>
 
+                        <Button
+                            android:id="@+id/email_com_et"
+                            android:layout_width="120dp"
+                            android:layout_height="40dp"
+                            android:hint="\u0040website.com"
+                            android:background="@drawable/signup_eidt"
+                            android:letterSpacing="-0.05"
+                            android:fontFamily="@font/nixgonm"
+                            android:gravity="center"
+                            android:maxLines="1"
+                            app:layout_constraintEnd_toEndOf="@id/pwd_ck_et"
+                            app:layout_constraintTop_toTopOf="parent"/>
+
                         <TextView
-                            android:id="@+id/id_ck_txt"
+                            android:id="@+id/email_ck_txt"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:fontFamily="@font/nixgonm"
-                            app:layout_constraintTop_toBottomOf="@id/id_et"
-                            app:layout_constraintEnd_toEndOf="@id/id_et"
+                            app:layout_constraintTop_toBottomOf="@id/email_com_et"
+                            app:layout_constraintEnd_toEndOf="@id/email_com_et"
                             android:paddingTop="2dp"
                             android:textColor="@color/pastel_pink"/>
 
-                        <Button
-                            android:id="@+id/id_ck_btn"
-                            android:layout_width="60dp"
-                            android:layout_height="40dp"
-                            android:text="중복확인"
-                            android:textSize="15sp"
-                            android:letterSpacing="-0.05"
-                            android:fontFamily="@font/nixgonm"
-                            android:background="@drawable/radius"
-                            android:backgroundTint="@color/patel_yellow"
-                            app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"/>
 
                         <TextView
                             android:id="@+id/pwd_tv"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="비밀번호*"
+                            android:text="비밀번호"
                             android:textColor="@color/black"
                             android:fontFamily="@font/nixgonm"
-                            android:textSize="20sp"
+                            android:textSize="18sp"
                             app:layout_constraintLeft_toLeftOf="parent"
                             app:layout_constraintTop_toTopOf="@id/pwd_et"
                             android:paddingTop="10dp"
@@ -148,7 +148,7 @@
                             android:letterSpacing="-0.05"
                             android:gravity="center"
                             app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/id_et"
+                            app:layout_constraintTop_toBottomOf="@id/email_id_et"
                             android:layout_marginTop="25dp"
                             android:maxLength="15"
                             android:maxLines="1"/>
@@ -174,59 +174,6 @@
                             android:fontFamily="@font/nixgonm"
                             app:layout_constraintTop_toBottomOf="@id/pwd_ck_et"
                             app:layout_constraintEnd_toEndOf="@id/pwd_ck_et"
-                            android:paddingTop="2dp"
-                            android:textColor="@color/pastel_pink"/>
-
-                        <TextView
-                            android:id="@+id/email_tv"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="이메일*"
-                            android:textColor="@color/black"
-                            android:fontFamily="@font/nixgonm"
-                            android:textSize="20sp"
-                            app:layout_constraintLeft_toLeftOf="parent"
-                            app:layout_constraintTop_toTopOf="@id/email_id_et"
-                            android:paddingTop="10dp"/>
-
-                        <EditText
-                            android:id="@+id/email_id_et"
-                            android:layout_width="wrap_content"
-                            android:layout_height="40dp"
-                            android:ems="7"
-                            android:hint="abc1234"
-                            android:background="@drawable/signup_eidt"
-                            android:letterSpacing="-0.05"
-                            android:fontFamily="@font/nixgonm"
-                            android:maxLines="1"
-                            android:gravity="center"
-                            app:layout_constraintStart_toStartOf="@id/pwd_ck_et"
-                            app:layout_constraintTop_toBottomOf="@id/pwd_ck_et"
-                            android:layout_marginTop="25dp"
-                            android:singleLine="true"
-                            android:imeOptions="actionDone"/>
-
-                        <Button
-                            android:id="@+id/email_com_et"
-                            android:layout_width="120dp"
-                            android:layout_height="40dp"
-                            android:hint="\u0040website.com"
-                            android:background="@drawable/signup_eidt"
-                            android:letterSpacing="-0.05"
-                            android:fontFamily="@font/nixgonm"
-                            android:gravity="center"
-                            android:maxLines="1"
-                            app:layout_constraintEnd_toEndOf="@id/pwd_ck_et"
-                            app:layout_constraintTop_toBottomOf="@id/pwd_ck_et"
-                            android:layout_marginTop="25dp"/>
-
-                        <TextView
-                            android:id="@+id/email_ck_txt"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:fontFamily="@font/nixgonm"
-                            app:layout_constraintTop_toBottomOf="@id/email_com_et"
-                            app:layout_constraintEnd_toEndOf="@id/email_com_et"
                             android:paddingTop="2dp"
                             android:textColor="@color/pastel_pink"/>
 

--- a/app/src/main/res/layout/fragment_auth_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_auth_bottom_sheet.xml
@@ -63,28 +63,17 @@
             android:layout_marginBottom="20dp"/>
 
         <Button
-            android:id="@+id/google_auth"
+            android:id="@+id/email_auth"
             android:layout_width="300dp"
             android:layout_height="wrap_content"
             android:background="@drawable/googlebtn"
-            android:text="구글로 인증"
+            android:text="이메일 인증"
             android:fontFamily="@font/nixgonm"
             android:textSize="20sp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintBottom_toTopOf="@id/num_auth"
             android:layout_marginBottom="20dp"/>
-
-
-
-        <ImageView
-            android:layout_width="42dp"
-            android:layout_height="42dp"
-            android:src="@drawable/googlelogo"
-            app:layout_constraintStart_toStartOf="@id/google_auth"
-            android:layout_marginStart="18dp"
-            app:layout_constraintTop_toTopOf="@id/google_auth"
-            app:layout_constraintBottom_toBottomOf="@id/google_auth"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </FrameLayout>


### PR DESCRIPTION
# 인증방식
파이어베이스에서 문자인증을 할 수는 있지만, 이 경우 전화번호로 계정이 또 하나 생성됨.
우리는 이메일 - 비밀번호를 입력해서 로그인 하고 싶음.
때문에 문자인증하는 방식 그대로 사용하면 안됨.

때문에 우선 회원가입 페이지에서 이메일 비밀번호를 입력하고 다음 버튼을 누르면
파이어베이스에 해당 이메일과 비밀번호로 계정 생성이됨
이 때 이메일과 비밀번호로 만든 계정의 uid(고유번호)를 문자인증 페이지로 넘겨줌.
그리고 문자인증 페이지로 넘어감.
여기서 전화번호를 입력하고, 문자인증을 진행함.

**문자인증에 성공하면**, 파이어베이스에 해당 전화번호로 계정이 또 생기니까 인증에 성공하자마자 그 계정은 삭제함.
그리고 이전에 전달받은 uid(이메일-비밀번호 로그인) 값을 서버로 넘겨줌
서버는 해당 uid를 기본키로하는 테이블을 생성함

우리 화면에서는 이제 상세정보입력 페이지로 넘어감
역시나 uid 값과 함께 입력한 상세정보를 전달해줌으로써 알맞은 테이블에 정보가 입력될 수 있게함.


### 예외처리
* 만약 필수정보입력(이메일-비밀번호 가입)을 진행하고 인증은 하지 않는다면?
-> 때문에 메인 페이지에서 로그인된 user의 uid값이 서버에 있는지 확인해서, 없다면 인증페이지로 넘어가고 있다면 찐 메인화면으로 넘어가게함.
* 만약 인증까지하고 추가정보 입력을 안했다면?
-> 메인페이지에서 로그인된 user의 uid값의 테이블 내부에 추가정보가 있는지 없는지 확인을해서, 없다면 상세정보입력페이지로 있다면 찐 메인화면으로 넘어가게함.


# 통신 넣어야 할 부분
_위에 길게길게 설명이 되어있긴 하나, 이해를 돕기 위한거고, 이 부분만 잘 되면 됨_
### MainActivity.kt
* (로그인이 되어있을 때) uid 값이 서버에 저장되어있는지 확인. true면 아래로, false면 NumAuth 페이지로
* (위에가 true일 때) uid 값이 기본키인 테이블 내부에 상세정보가 입력되어있는지 확인. true면 찐 메인화면으로, false면 DetaiInfoActivity로

### NumAuth.kt
* 문자인증 성공시 (위치는 주석해놨음) 전달받은 uid로 서버에 테이블 생성

그리고 문자 인증 동시에 여러번 요청하거나, 같은 번호로 계속 요청하면 몇시간에서 하루정도 차단된대
아마 너가 막 눌러서 차단 됐을 수도 있음
https://stackoverflow.com/questions/65792764/sms-verification-code-request-failed-when-authenticating-using-firebase-auth

암튼 위에 읽어보고... 이해안되는부분있으면 말해주셈
월요일에 나 학교 못가니까 통신을 너가 해봐야할듯